### PR TITLE
DF-6 Make old opens not count

### DIFF
--- a/img.php
+++ b/img.php
@@ -35,9 +35,22 @@ $entry = $DB->get_record('digestforum_tracker', ['id' => $id]);
 
 if ($entry) {
 
-    // The email has been viewed. Update info.
+    // Parse the digestdate, which is yyyy-mm-dd or yyyy-mm-d to see if this view counts.
+    $year = substr($entry->digestdate, 0, 4);
+    $mon = substr($entry->digestdate, 5, 2);
+    $day = substr($entry->digestdate, 8);
+    
+    $origdate = new DateTime();
+    $origdate->setDate($year, $mon, $day);
     $now = time();
-    $entry->numviews++;
+
+    // Only count it as an open if it's been within a week.
+    $valid = (($now - (7 * 86400)) < $origdate->getTimestamp());
+    if ($valid) {
+        $entry->numviews++;
+    }
+
+    // The email has been viewed. Update info.
     if ($entry->firstviewed == 0) {
         $entry->firstviewed = $now;
     }


### PR DESCRIPTION
Don't count any opens that occur a week after the email was sent.

This should close #6.